### PR TITLE
hostapd: add missing #ifdef for non-802.11ax builds

### DIFF
--- a/package/network/services/hostapd/src/src/ap/ucode.c
+++ b/package/network/services/hostapd/src/src/ap/ucode.c
@@ -332,16 +332,21 @@ uc_hostapd_iface_start(uc_vm_t *vm, size_t nargs)
 		conf->channel = intval;
 	if ((intval = ucv_int64_get(ucv_object_get(info, "sec_channel", NULL))) && !errno)
 		conf->secondary_channel = intval;
+#ifdef CONFIG_IEEE80211AC
 	if ((intval = ucv_int64_get(ucv_object_get(info, "center_seg0_idx", NULL))) && !errno) {
 		conf->vht_oper_centr_freq_seg0_idx = intval;
+#ifdef CONFIG_IEEE80211AX
 		conf->he_oper_centr_freq_seg0_idx = intval;
+#endif
 #ifdef CONFIG_IEEE80211BE
 		conf->eht_oper_centr_freq_seg0_idx = intval;
 #endif
 	}
 	if ((intval = ucv_int64_get(ucv_object_get(info, "center_seg1_idx", NULL))) && !errno) {
 		conf->vht_oper_centr_freq_seg1_idx = intval;
+#ifdef CONFIG_IEEE80211AX
 		conf->he_oper_centr_freq_seg1_idx = intval;
+#endif
 #ifdef CONFIG_IEEE80211BE
 		conf->eht_oper_centr_freq_seg1_idx = intval;
 #endif
@@ -349,11 +354,14 @@ uc_hostapd_iface_start(uc_vm_t *vm, size_t nargs)
 	intval = ucv_int64_get(ucv_object_get(info, "oper_chwidth", NULL));
 	if (!errno) {
 		conf->vht_oper_chwidth = intval;
+#ifdef CONFIG_IEEE80211AX
 		conf->he_oper_chwidth = intval;
+#endif
 #ifdef CONFIG_IEEE80211BE
 		conf->eht_oper_chwidth = intval;
 #endif
 	}
+#endif
 
 out:
 	if (conf->channel)


### PR DESCRIPTION
Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
