### PR TITLE
luci: fix firewall-app for stable 4.4.6

### DIFF
--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -1,5 +1,5 @@
 src-git packages https://git.openwrt.org/feed/packages.git
-src-git luci https://github.com/pesa1234/luci.git;next-r4
+src-git luci https://github.com/pesa1234/luci.git^891635090c74f53c117e2fa22442eb10a1db6a33
 src-git routing https://git.openwrt.org/feed/routing.git
 src-git telephony https://git.openwrt.org/feed/telephony.git
 src-git video https://github.com/openwrt/video.git


### PR DESCRIPTION
Hi pesa1234, many many thanks for all your work!

I tried to build the last stable 4.4.6 (as per the forum thread). All looks good except one issue:

As on 4.4.6 mtkhnat is not available, breaking the firewall overview page:
![Screenshot 2025-02-16 113324](https://github.com/user-attachments/assets/68ceb216-8b81-4fd0-bb24-3cb20cfc06a7)

With this change (i.e. pinning the last commit before your implementation for mtkhnat) the "stable" version can still be used for custom builds.